### PR TITLE
fix: add --no-border-checks flag to recover from source-map-explorer errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,29 +38,30 @@ npm install --save-dev react-native-bundle-visualizer ./node_modules/.bin/react-
 
 All command-line arguments are optional. By default a production build will be created for the `ios` platform.
 
-| Option          | Description                                                                                                                                                  | Example                          |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
-| `platform`      | Platform to build (default is **ios**)                                                                                                                       | `--platform ios`                 |
-| `dev`           | Dev or production build (default is **false**)                                                                                                               | `--dev false`                    |
-| `entry-file`    | Entry-file (when omitted tries to auto-resolve it)                                                                                                           | `--entry-file ./index.ios.js`    |
-| `bundle-output` | Output bundle-file (default is **tmp**)                                                                                                                      | `--bundle-output ./myapp.bundle` |
-| `format`        | Output format **html**, **json** or **tsv** (default is **html**) (see [source-map-explorer options][smeo])                                                  | `--format json`                  |
-| `only-mapped`   | Exclude "unmapped" bytes from the output (default is **false**). This will result in total counts less than the file size.                                   | `--only-mapped`                  |
-| `verbose`       | Dumps additional output to the console (default is **false**)                                                                                                | `--verbose`                      |
-| `reset-cache`   | Removes cached react-native files (default is **false**)                                                                                                     | `--reset-cache`                  |
-| `--expo`   | Set this to true/ false based on whether using expo or not. For eg, set `--expo true` when using expo. Not required to pass this for react-native cli. (default is **false**)                                                                                                     | `--expo false`                  |
+| Option               | Description                                                                                                                                                                   | Example                          |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `platform`           | Platform to build (default is **ios**)                                                                                                                                        | `--platform ios`                 |
+| `dev`                | Dev or production build (default is **false**)                                                                                                                                | `--dev false`                    |
+| `entry-file`         | Entry-file (when omitted tries to auto-resolve it)                                                                                                                            | `--entry-file ./index.ios.js`    |
+| `bundle-output`      | Output bundle-file (default is **tmp**)                                                                                                                                       | `--bundle-output ./myapp.bundle` |
+| `format`             | Output format **html**, **json** or **tsv** (default is **html**) (see [source-map-explorer options][smeo])                                                                   | `--format json`                  |
+| `only-mapped`        | Exclude "unmapped" bytes from the output (default is **false**). This will result in total counts less than the file size.                                                    | `--only-mapped`                  |
+| `verbose`            | Dumps additional output to the console (default is **false**)                                                                                                                 | `--verbose`                      |
+| `reset-cache`        | Removes cached react-native files (default is **false**)                                                                                                                      | `--reset-cache`                  |
+| `--expo`             | Set this to true/ false based on whether using expo or not. For eg, set `--expo true` when using expo. Not required to pass this for react-native cli. (default is **false**) | `--expo false`                   |
+| `--no-border-checks` | Pass the same flag to the underlying `source-map-explorer` to disable invalid mapping column/line checks.                                                                     | `--no-border-checks`             |
 
 [smeo]: https://github.com/danvk/source-map-explorer#options
 
->Use [react-native-bundle-visualizer@2](https://github.com/IjzerenHein/react-native-bundle-visualizer/tree/v2) when targetting Expo SDK 40 or lower.
+> Use [react-native-bundle-visualizer@2](https://github.com/IjzerenHein/react-native-bundle-visualizer/tree/v2) when targetting Expo SDK 40 or lower.
 
 ## Version compatibility
 
-| Version                                                                       | Comments                                                                                                                                                              |
-| ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 3.x                                                                           | Compatible with React-Native CLI bootstrapped projects and Expo SDK 41 or higher. | 
-| [2.x](https://github.com/IjzerenHein/react-native-bundle-visualizer/tree/v2) | Compatible with React-Native CLI bootstrapped projects and Expo SDK 40 or earlier.                                                                                                           |
-| [1.x](https://github.com/IjzerenHein/react-native-bundle-visualizer/tree/v1) | Uses the [Haul bundler](https://github.com/callstack/haul) instead instead of the Metro output. | 
+| Version                                                                      | Comments                                                                                        |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| 3.x                                                                          | Compatible with React-Native CLI bootstrapped projects and Expo SDK 41 or higher.               |
+| [2.x](https://github.com/IjzerenHein/react-native-bundle-visualizer/tree/v2) | Compatible with React-Native CLI bootstrapped projects and Expo SDK 40 or earlier.              |
+| [1.x](https://github.com/IjzerenHein/react-native-bundle-visualizer/tree/v1) | Uses the [Haul bundler](https://github.com/callstack/haul) instead instead of the Metro output. |
 
 ## License
 

--- a/src/react-native-bundle-visualizer.js
+++ b/src/react-native-bundle-visualizer.js
@@ -69,6 +69,7 @@ const bundleOutputSourceMap = bundleOutput + '.map';
 const format = argv.format || 'html';
 const bundleOutputExplorerFile = path.join(outDir, 'explorer.' + format);
 const onlyMapped = !!argv['only-mapped'] || false;
+const borderChecks = argv['border-checks'] || false;
 
 // Make sure the temp dir exists
 fs.ensureDirSync(baseDir);
@@ -96,7 +97,7 @@ const commands = [
   '--sourcemap-output',
   bundleOutputSourceMap,
   '--minify',
-  isExpo
+  isExpo,
 ];
 if (resetCache) {
   commands.push('--reset-cache');
@@ -147,6 +148,7 @@ bundlePromise
         },
         {
           onlyMapped,
+          noBorderChecks: borderChecks === false,
           output: {
             format,
             filename: bundleOutputExplorerFile,
@@ -181,7 +183,5 @@ bundlePromise
 
     // Open output file
     return open(bundleOutputExplorerFile);
-  }).catch(error => console.log(
-    chalk.red('=== error ==='),
-    error
-  ));
+  })
+  .catch((error) => console.log(chalk.red('=== error ==='), error));


### PR DESCRIPTION


## Description

On latest few versions of React Native (checked on 0.75 and above), the `source-map-explorer` dependency is crashing by incorrect mappings produced by Metro bundler:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/10878563-35a2-40be-b352-223bda53c185" />

which bleeds to `react-native-bundle-visualizer`:
<img width="750" alt="image" src="https://github.com/user-attachments/assets/1edda7c5-f3a1-4efa-9d7f-e790760da3e4" />

To fix that, we can pass `--no-border-checks` flag to `source-map-explorer`, which avoids failure and can still produce the visual information, at least in my test project. As a non-breaking solution I'm adding the same flag to the `react-native-bundle-visualizer`

## Test Plan

<img width="751" alt="image" src="https://github.com/user-attachments/assets/91737341-dcec-4336-9a87-6c59bd61394e" />
